### PR TITLE
mark events that are already in progress #16

### DIFF
--- a/src/app/event.spec.ts
+++ b/src/app/event.spec.ts
@@ -1,4 +1,9 @@
-import { Event } from './event';
+import {
+  Event,
+  EventStateNotStarted,
+  EventStateInProgress,
+  EventStateFinished,
+} from './event';
 
 describe('Event', () => {
   let event: Event;
@@ -19,8 +24,8 @@ describe('Event', () => {
   });
 
   it('should know it has not happened when it is in the future', () => {
-    event.datetime = new Date('2021-03-06T20:00:00Z');
-    expect(event.alreadyHappened()).toBeTrue();
+    event.datetime = new Date('2121-03-06T20:00:00Z');
+    expect(event.alreadyHappened()).toBeFalse();
   });
 
   it('should return the name of the day from dayInTimezone', () => {
@@ -29,5 +34,64 @@ describe('Event', () => {
 
   it('should return a readable date and time from timeInTimezone', () => {
     expect(event.timeInTimezone('Europe/London')).toBe('Saturday 20:00');
+  });
+
+  describe('called', () => {
+    beforeEach(() => {
+      jasmine.clock().install();
+    });
+
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
+    describe('before the event', () => {
+      beforeEach(() => {
+        /* this is 24 hours before the event starts */
+        jasmine.clock().mockDate(new Date('2021-03-05T20:00:00Z'));
+      });
+
+      it('should return 0 if event has not happened yet', () => {
+        expect(event.finishedPercentage()).toBe(0);
+      });
+
+      it('should have state EventStateNotStarted', () => {
+        expect(event.state()).toBe(EventStateNotStarted);
+      });
+    });
+
+    describe('during the event', () => {
+      beforeEach(() => {
+        /* this is one hour into the event */
+        jasmine.clock().mockDate(new Date('2021-03-06T21:00:00Z'));
+      });
+
+      it('should calculate how much much of its time has passed already', () => {
+        expect(event.finishedPercentage()).toBe(50);
+
+        /* move time forward by a little more than two minutes */
+        jasmine.clock().tick(121 * 1000);
+        expect(event.finishedPercentage()).toBe(51);
+      });
+
+      it('should have state EventStateInProgress', () => {
+        expect(event.state()).toBe(EventStateInProgress);
+      });
+    });
+
+    describe('after the event', () => {
+      beforeEach(() => {
+        /* this is 1 hour after the event ended */
+        jasmine.clock().mockDate(new Date('2021-03-06T23:00:00Z'));
+      });
+
+      it('should return 100 if event is over', () => {
+        expect(event.finishedPercentage()).toBe(100);
+      });
+
+      it('should have state EventStateFinished', () => {
+        expect(event.state()).toBe(EventStateFinished);
+      });
+    });
   });
 });

--- a/src/app/events/events.component.html
+++ b/src/app/events/events.component.html
@@ -5,9 +5,9 @@
       <mat-card
         class="event-card"
         *ngFor="let event of day.value"
-        matTooltip="This event has already happened"
-        [matTooltipDisabled]="event.alreadyHappened() === false"
+        [matTooltip]="tooltips[event.state()]"
         [class.past-event]="event.alreadyHappened()"
+        [style.background]="getBackgroundGradient(event)"
       >
         <mat-card-header>
           <a

--- a/src/app/events/events.component.scss
+++ b/src/app/events/events.component.scss
@@ -2,6 +2,7 @@
     display: flex;
     flex: 1 1 auto;
     overflow: auto;
+    --past-bg-color: rgba(236,236,236,1);
 }
 
 .events-container {
@@ -30,7 +31,7 @@
 
 .past-event {
     color: #8D8D8D;
-    background-color: #FCFCFC;
+    background-color: var(--past-bg-color);
     a {
         color: #858585;
     }

--- a/src/app/events/events.component.ts
+++ b/src/app/events/events.component.ts
@@ -1,5 +1,10 @@
 import { Component, Input } from '@angular/core';
-import { Event } from '../event';
+import {
+  Event,
+  EventStateNotStarted,
+  EventStateInProgress,
+  EventStateFinished,
+} from '../event';
 
 @Component({
   selector: 'app-events',
@@ -12,4 +17,16 @@ export class EventsComponent {
 
   @Input()
   timezone: string;
+
+  tooltips = {
+    [EventStateNotStarted]: 'This event has not started yet',
+    [EventStateInProgress]:
+      'This event is currently in progress, but you can still join',
+    [EventStateFinished]: 'This event has already happened',
+  };
+
+  getBackgroundGradient(event: Event): string {
+    const percentage = event.finishedPercentage();
+    return `linear-gradient(90deg, var(--past-bg-color) ${percentage}%, rgba(255,255,255,0) ${percentage}%)`;
+  }
 }


### PR DESCRIPTION
This commit also enables tooltips for every state an event can be in and
changes the background colour of past events so that progress can be
visualised as a patial background.

Fixes #16